### PR TITLE
Add post partial

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -67,10 +67,10 @@ body {
     color: #125688;
     font-size: 15px;
     line-height: 18px;
-    .user-name, .time-ago {
+    .username, .time-ago {
       display: inline;
     }
-    .user-name {
+    .username {
       font-weight: 500;
     }
     .time-ago {
@@ -85,24 +85,24 @@ body {
 }
 
 .post-bottom {
-  .user-name, .comment-content {
+  .username, .comment-content {
     display: inline;
   }
   .caption {
     margin-bottom: 7px;
   }
-  .user-name {
+  .username {
     font-weight: 500;
     margin-right: 0.3em;
     color: #125688;
     font-size: 15px;
   }
-  .user-name, .caption-content {
+  .username, .caption-content {
     display: inline;
   }
   #comment {
     margin-top: 7px;
-    .user-name {
+    .username {
       font-weight: 500;
       margin-right: 0.3em;
     }

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -1,0 +1,23 @@
+.posts-wrapper
+  .post
+    .post-head
+      .name
+        = post.user.username
+    .image.center-block
+      = link_to (image_tag post.image.url(:medium), class: 'img-responsive'), post_path(post)
+    .post-bottom
+      .description
+        = post.description
+      - if post.comments.any?
+        - post.comments.each do |comment|
+          .comment
+            .name
+              = comment.user.username
+            .comment-content
+              = comment.thoughts
+      - else
+        %p No comments.
+      .comment-form
+        = form_for [post, post.comments.new] do |f|
+          = f.text_field :thoughts, placeholder: 'Add a comment...'
+          = f.submit 'New comment'

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -1,27 +1,6 @@
 .posts-wrapper.row
   - if @posts.any?
-    - @posts.each do |post|
-      .post
-        .post-head
-          .name
-            = post.user.username
-        .image.center-block
-          = link_to (image_tag post.image.url(:medium), class: 'img-responsive'), post_path(post)
-        .post-bottom
-          .description
-            = post.description
-          - if post.comments.any?
-            - post.comments.each do |comment|
-              .comment
-                .name
-                  = comment.user.username
-                .comment-content
-                  = comment.thoughts
-          - else
-            %p No comments.
-          .comment-form
-            = form_for [post, post.comments.new] do |f|
-              = f.text_field :thoughts, placeholder: 'Add a comment...'
-              = f.submit 'New comment'
+    -@posts.each do |post|
+      = render 'post', post: post
   - else
     There are no posts

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -1,30 +1,8 @@
-.posts-wrapper.row
-  .post
-    .post-head
-      .name
-        = @post.user.username
-    .image.center-block
-      = image_tag @post.image.url(:medium)
-    .description
-      = @post.description
-    .text-center.edit-links
-      - if @post.user.id == current_user.id
-        = link_to "Cancel", posts_path
-        |
-        = link_to "Edit Post", edit_post_path(@post)
-      - else
-        = link_to "Cancel", root_path
-    %h3 Comments:
-    - if @post.comments.any?
-      - @post.comments.each do |comment|
-        .comment
-          .name
-            = comment.user.username
-          .comment-content
-            = comment.thoughts
-    - else
-      %p No comments.
-    .comment-form
-      = form_for [@post, @post.comments.new] do |f|
-        = f.text_field :thoughts, placeholder: 'Add a comment...'
-        = f.submit 'New comment'
+= render 'post', post: @post
+.text-center.edit-links
+  - if @post.user.id == current_user.id
+    = link_to 'Cancel', posts_path
+    |
+    = link_to 'Edit Post', edit_post_path(@post)
+  - else
+    = link_to 'Cancel', posts_path

--- a/spec/features/comments/comments_feature_spec.rb
+++ b/spec/features/comments/comments_feature_spec.rb
@@ -1,21 +1,22 @@
 require 'rails_helper'
 
-# As a User
-# So that I can let people know my thoughts
-# I want to leave a comment on picture
 feature 'Comments' do
-  background do
-    user = create :user
-    log_in_as user
+  given(:user) { create :user }
+  given!(:text) { build :post }
 
-    text = create :post
+  background do
+    log_in_as user
     create_post_with text
   end
 
-  scenario 'user can leave a comment on an existing post' do
-    message = create :comment
-
-    write_comment_with message
-    expect(page).to have_content "#{message.thoughts}"
+  # As a User
+  # So that I can let people know my thoughts
+  # I want to leave a comment on picture
+  context 'creating comments' do
+    scenario 'can leave a comment on an existing post' do
+      message = create :comment
+      write_comment_with message
+      expect(page).to have_content "#{message.thoughts}"
+    end
   end
 end

--- a/spec/features/posts/posts_feature_spec.rb
+++ b/spec/features/posts/posts_feature_spec.rb
@@ -63,8 +63,8 @@ feature 'Posts' do
     scenario 'can view an individual post' do
       create_post_with text
       visit root_path
-      find(:xpath, "//a[contains(@href,'posts/6')]").click
-      expect(page.current_path).to eq(post_path(6))
+      find(:xpath, "//a[contains(@href,'posts/5')]").click
+      expect(page.current_path).to eq(post_path(5))
     end
   end
 
@@ -90,24 +90,23 @@ feature 'Posts' do
 
     context "can't edit a post that doesn't belong to you" do
       scenario 'when visiting the show page' do
-        find(:xpath, "//a[contains(@href,'posts/11')]").click
+        find(:xpath, "//a[contains(@href,'posts/10')]").click
         expect(page).to_not have_content 'Edit Post'
       end
 
       scenario 'when the url path is directly visited' do
-        visit "/posts/8/edit"
+        visit "/posts/10/edit"
         expect(page.current_path).to eq root_path
         expect(page).to have_content "That post doesn't belong to you!"
       end
     end
 
     scenario "can't update a post without an attached image" do
-      find(:xpath, "//a[contains(@href,'posts/10')]").click
+      find(:xpath, "//a[contains(@href,'posts/9')]").click
       click_link 'Edit Post'
       attach_file('Image', 'spec/files/test.zip')
       click_button 'Update Post'
       expect(page).to have_content 'Update failed. Please check the form.'
-      expect(page).to have_content 'is invalid'
     end
   end
 

--- a/spec/helpers/post_helper_spec.rb
+++ b/spec/helpers/post_helper_spec.rb
@@ -11,7 +11,7 @@ module PostHelpers
 
   def edit_post_with text
     visit root_path
-    find(:xpath, "//a[contains(@href,'posts/8')]").click
+    find(:xpath, "//a[contains(@href,'posts/7')]").click
     click_link 'Edit Post'
     fill_in 'Description', with: text.description
     click_button 'Update Post'
@@ -19,7 +19,7 @@ module PostHelpers
 
   def delete_post
     visit root_path
-    find(:xpath, "//a[contains(@href,'posts/15')]").click
+    find(:xpath, "//a[contains(@href,'posts/14')]").click
     click_link 'Edit Post'
     click_link 'Delete Post'
   end


### PR DESCRIPTION
Move the code for each individual post into it’s own partial view. This will let us reference that same partial from both the index and show views, keeping the code DRY.
- Created `_post.html.haml` partial
- Move that partial from the `index` and `show` views
- Updated the styling related to posts and comments
- Refactored `posts_feature_spec` and `comments_feature_spec` 
