### PR TITLE
Add deleting comments

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -1,0 +1,70 @@
+# Whether to ignore frontmatter at the beginning of HAML documents for
+# frameworks such as Jekyll/Middleman
+skip_frontmatter: false
+
+linters:
+  AltText:
+    enabled: false
+
+  ClassAttributeWithStaticValue:
+    enabled: true
+
+  ClassesBeforeIds:
+    enabled: true
+
+  ConsecutiveComments:
+    enabled: true
+
+  ConsecutiveSilentScripts:
+    enabled: true
+    max_consecutive: 2
+
+  EmptyScript:
+    enabled: true
+
+  HtmlAttributes:
+    enabled: true
+
+  ImplicitDiv:
+    enabled: true
+
+  LeadingCommentSpace:
+    enabled: true
+
+  LineLength:
+    enabled: true
+    max: 80
+
+  MultilinePipe:
+    enabled: true
+
+  MultilineScript:
+    enabled: true
+
+  ObjectReferenceAttributes:
+    enabled: true
+
+  RuboCop:
+    enabled: false
+
+  RubyComments:
+    enabled: true
+
+  SpaceBeforeScript:
+    enabled: true
+
+  SpaceInsideHashAttributes:
+    enabled: true
+    style: space
+
+  TagName:
+    enabled: true
+
+  TrailingWhitespace:
+    enabled: true
+
+  UnnecessaryInterpolation:
+    enabled: true
+
+  UnnecessaryStringOutput:
+    enabled: true

--- a/.hound.yml
+++ b/.hound.yml
@@ -4,3 +4,9 @@ ruby:
 
 javascript:
   config_file: .javascript-style.json
+
+scss:
+  config_file: .scss-lint.yml
+
+haml:
+  config_file: .haml-lint.yml

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,246 @@
+scss_files: "**/*.scss"
+plugin_directories: ['.scss-linters']
+
+plugin_gems: []
+
+linters:
+  BangFormat:
+    enabled: true
+    space_before_bang: true
+    space_after_bang: false
+
+  BemDepth:
+    enabled: false
+    max_elements: 1
+
+  BorderZero:
+    enabled: true
+    convention: none # or `zero`
+
+  ChainedClasses:
+    enabled: false
+
+  ColorKeyword:
+    enabled: true
+
+  ColorVariable:
+    enabled: true
+
+  Comment:
+    enabled: true
+    style: silent
+
+  DebugStatement:
+    enabled: true
+
+  DeclarationOrder:
+    enabled: true
+
+  DisableLinterReason:
+    enabled: false
+
+  DuplicateProperty:
+    enabled: true
+
+  ElsePlacement:
+    enabled: true
+    style: same_line # or 'new_line'
+
+  EmptyLineBetweenBlocks:
+    enabled: true
+    ignore_single_line_blocks: true
+
+  EmptyRule:
+    enabled: true
+
+  ExtendDirective:
+    enabled: false
+
+  FinalNewline:
+    enabled: true
+    present: true
+
+  HexLength:
+    enabled: false
+    style: short # or 'long'
+
+  HexNotation:
+    enabled: true
+    style: lowercase # or 'uppercase'
+
+  HexValidation:
+    enabled: true
+
+  IdSelector:
+    enabled: true
+
+  ImportantRule:
+    enabled: true
+
+  ImportPath:
+    enabled: true
+    leading_underscore: false
+    filename_extension: false
+
+  Indentation:
+    enabled: true
+    allow_non_nested_indentation: false
+    character: space # or 'tab'
+    width: 2
+
+  LeadingZero:
+    enabled: true
+    style: include_zero # or 'exclude_zero'
+
+  MergeableSelector:
+    enabled: true
+    force_nesting: true
+
+  NameFormat:
+    enabled: true
+    allow_leading_underscore: true
+    convention: hyphenated_lowercase # or 'camel_case', or 'snake_case', or a regex pattern
+
+  NestingDepth:
+    enabled: true
+    max_depth: 4
+    ignore_parent_selectors: false
+
+  PlaceholderInExtend:
+    enabled: false
+
+  PrivateNamingConvention:
+    enabled: false
+    prefix: _
+
+  PropertyCount:
+    enabled: true
+    include_nested: false
+    max_properties: 10
+
+  PropertySortOrder:
+    enabled: true
+    ignore_unspecified: false
+    min_properties: 2
+    separate_groups: false
+
+  PropertySpelling:
+    enabled: true
+    extra_properties: []
+    disabled_properties: []
+
+  PropertyUnits:
+    enabled: true
+    global: [
+      'ch', 'em', 'ex', 'rem',                 # Font-relative lengths
+      'cm', 'in', 'mm', 'pc', 'pt', 'px', 'q', # Absolute lengths
+      'vh', 'vw', 'vmin', 'vmax',              # Viewport-percentage lengths
+      'deg', 'grad', 'rad', 'turn',            # Angle
+      'ms', 's',                               # Duration
+      'Hz', 'kHz',                             # Frequency
+      'dpi', 'dpcm', 'dppx',                   # Resolution
+      '%']                                     # Other
+    properties: {}
+
+  PseudoElement:
+    enabled: true
+
+  QualifyingElement:
+    enabled: true
+    allow_element_with_attribute: false
+    allow_element_with_class: false
+    allow_element_with_id: false
+
+  SelectorDepth:
+    enabled: true
+    max_depth: 2
+
+  SelectorFormat:
+    enabled: true
+    convention: hyphenated_lowercase # or 'strict_BEM', or 'hyphenated_BEM', or 'snake_case', or 'camel_case', or a regex pattern
+
+  Shorthand:
+    enabled: true
+    allowed_shorthands: [1, 2, 3]
+
+  SingleLinePerProperty:
+    enabled: true
+    allow_single_line_rule_sets: true
+
+  SingleLinePerSelector:
+    enabled: true
+
+  SpaceAfterComma:
+    enabled: true
+    style: one_space # or 'no_space', or 'at_least_one_space'
+
+  SpaceAfterPropertyColon:
+    enabled: true
+    style: one_space # or 'no_space', or 'at_least_one_space', or 'aligned'
+
+  SpaceAfterPropertyName:
+    enabled: true
+
+  SpaceAfterVariableColon:
+    enabled: false
+    style: one_space # or 'no_space', 'at_least_one_space' or 'one_space_or_newline'
+
+  SpaceAfterVariableName:
+    enabled: true
+
+  SpaceAroundOperator:
+    enabled: true
+    style: one_space # or 'at_least_one_space', or 'no_space'
+
+  SpaceBeforeBrace:
+    enabled: true
+    style: space # or 'new_line'
+    allow_single_line_padding: false
+
+  SpaceBetweenParens:
+    enabled: true
+    spaces: 0
+
+  StringQuotes:
+    enabled: true
+    style: double_quotes # or single_quotes
+
+  TrailingSemicolon:
+    enabled: true
+
+  TrailingWhitespace:
+    enabled: true
+
+  TrailingZero:
+    enabled: false
+
+  TransitionAll:
+    enabled: false
+
+  UnnecessaryMantissa:
+    enabled: true
+
+  UnnecessaryParentReference:
+    enabled: true
+
+  UrlFormat:
+    enabled: true
+
+  UrlQuotes:
+    enabled: true
+
+  VariableForProperty:
+    enabled: false
+    properties: []
+
+  VendorPrefix:
+    enabled: true
+    identifier_list: base
+    additional_identifiers: []
+    excluded_identifiers: []
+
+  ZeroUnit:
+    enabled: true
+
+  Compass::*:
+    enabled: false

--- a/README.md
+++ b/README.md
@@ -42,8 +42,12 @@ So that I can let people know my thoughts
 I want to leave a comment on picture
 
 As a User
-So that I can rectify what I originally write
-I want to edit/delete my comments
+So that I can rectify what I originally comment
+I want to delete my comments
+
+As a User
+So that I can protect comments from deleting by another user
+I want to delete comments that only belong to me
 
 As a User
 So that I can register my appreciation of the picture

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -102,6 +102,9 @@ body {
       font-weight: 500;
       margin-right: 0.3em;
     }
+    .delete-comment {
+      float: right;
+    }
   }
   margin-bottom: 5px;
   padding-left: 24px;

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,7 @@
 class CommentsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_post
+  before_action :owned_comment, only: [:destroy]
 
   def create
     @comment = @post.comments.build(comment_params)
@@ -19,10 +20,12 @@ class CommentsController < ApplicationController
 
   def destroy
     @comment = @post.comments.find(params[:id])
-    @comment.destroy
-    respond_to do |format|
-      format.html { redirect_to root_path }
-      format.js
+    if @comment.user_id == current_user.id
+      @comment.destroy
+      respond_to do |format|
+        format.html { redirect_to root_path }
+        format.js
+      end
     end
   end
 
@@ -34,5 +37,13 @@ class CommentsController < ApplicationController
 
   def set_post
     @post = Post.find(params[:post_id])
+  end
+
+  def owned_comment
+    @comment = current_user.comments.find_by(id: params[:id])
+    if @comment.nil?
+      flash[:alert] = "That comment doesn't belong to you!"
+      redirect_to root_path
+    end
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -17,6 +17,13 @@ class CommentsController < ApplicationController
     end
   end
 
+  def destroy
+    @comment = @post.comments.find(params[:id])
+    @comment.destroy
+    flash[:notice] = "Comment deleted successfully."
+    redirect_to root_path
+  end
+
   private
 
   def comment_params

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -20,12 +20,10 @@ class CommentsController < ApplicationController
 
   def destroy
     @comment = @post.comments.find(params[:id])
-    if @comment.user_id == current_user.id
-      @comment.destroy
-      respond_to do |format|
-        format.html { redirect_to root_path }
-        format.js
-      end
+    @comment.destroy
+    respond_to do |format|
+      format.html { redirect_to root_path }
+      format.js
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -20,8 +20,10 @@ class CommentsController < ApplicationController
   def destroy
     @comment = @post.comments.find(params[:id])
     @comment.destroy
-    flash[:notice] = "Comment deleted successfully."
-    redirect_to root_path
+    respond_to do |format|
+      format.html { redirect_to root_path }
+      format.js
+    end
   end
 
   private

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -3,4 +3,4 @@
     = comment.user.username
   .comment-content
     = comment.thoughts
-    = link_to "Delete", post_comment_path(post, comment), method: :delete, id: "delete-#{comment.id}"
+    = link_to "Delete", post_comment_path(post, comment), method: :delete, data: { confirm: "Are you sure?" }, remote: true, id: "delete_#{comment.id}", class: "delete-comment"

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -3,4 +3,5 @@
     = comment.user.username
   .comment-content
     = comment.thoughts
+  - if comment.user == current_user
     = link_to "Delete", post_comment_path(post, comment), method: :delete, data: { confirm: "Are you sure?" }, remote: true, id: "delete_#{comment.id}", class: "delete-comment"

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -3,3 +3,4 @@
     = comment.user.username
   .comment-content
     = comment.thoughts
+    = link_to "Delete", post_comment_path(post, comment), method: :delete, id: "delete-#{comment.id}"

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -4,4 +4,9 @@
   .comment-content
     = comment.thoughts
   - if comment.user == current_user
-    = link_to "Delete", post_comment_path(post, comment), method: :delete, data: { confirm: "Are you sure?" }, remote: true, id: "delete_#{comment.id}", class: "delete-comment"
+    = link_to "Delete", post_comment_path(post, comment),
+                        method: :delete,
+                        data: { confirm: "Are you sure?" },
+                        remote: true,
+                        id: "delete_#{comment.id}",
+                        class: "delete-comment"

--- a/app/views/comments/destroy.js.erb
+++ b/app/views/comments/destroy.js.erb
@@ -1,0 +1,1 @@
+$('#comments_<%= @post.id %>').html("<%= j render @post.comments, post: @post, comment: @comment %>");

--- a/spec/factories/comment.rb
+++ b/spec/factories/comment.rb
@@ -1,5 +1,8 @@
 FactoryGirl.define do
   factory :comment do
+    id 1
     thoughts 'This is my comment'
+    user_id 1
+    post_id 1
   end
 end

--- a/spec/features/comments/comments_feature_spec.rb
+++ b/spec/features/comments/comments_feature_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 feature 'Comments' do
-  given(:user) { create :user }
-  given!(:text) { build :post }
+  given(:user)     { create :user }
+  given(:user_two) { create(:user, username: 'paulsmith', email: 'paulsmith@email.com', id: 2) }
+  given(:text)     { build :post }
+  given(:message)  { build :comment }
 
   background do
     log_in_as user
@@ -14,20 +16,27 @@ feature 'Comments' do
   # I want to leave a comment on picture
   context 'creating comments' do
     scenario 'can leave a comment on an existing post' do
-      message = create :comment
       write_comment_with message
-      expect(page).to have_css ".comments#{text.id}", text: "#{message.thoughts}"
+      user_should_see_username_of user
+      user_should_see_comment message
     end
   end
 
+  # As a User
+  # So that I can rectify what I originally comment
+  # I want to delete my comment
   context 'deleting comments' do
+    background do
+      log_out
+      log_in_as user_two
+    end
+
     scenario 'can delete a comment on an existing post' do
-      message = create :comment
       write_comment_with message
-      expect(page).to have_content "#{message.thoughts}"
+      user_should_see_comment message
+      user_should_see_username_of user_two
       delete_comment
-      expect(page).to_not have_content "#{message.thoughts}"
-      expect(page).to have_content 'Comment deleted successfully.'
+      user_should_not_see_comment message
     end
   end
 end

--- a/spec/features/comments/comments_feature_spec.rb
+++ b/spec/features/comments/comments_feature_spec.rb
@@ -16,7 +16,18 @@ feature 'Comments' do
     scenario 'can leave a comment on an existing post' do
       message = create :comment
       write_comment_with message
+      expect(page).to have_css ".comments#{text.id}", text: "#{message.thoughts}"
+    end
+  end
+
+  context 'deleting comments' do
+    scenario 'can delete a comment on an existing post' do
+      message = create :comment
+      write_comment_with message
       expect(page).to have_content "#{message.thoughts}"
+      delete_comment
+      expect(page).to_not have_content "#{message.thoughts}"
+      expect(page).to have_content 'Comment deleted successfully.'
     end
   end
 end

--- a/spec/features/comments/comments_feature_spec.rb
+++ b/spec/features/comments/comments_feature_spec.rb
@@ -2,7 +2,9 @@ require 'rails_helper'
 
 feature 'Comments' do
   given(:user)     { create :user }
-  given(:user_two) { create(:user, username: 'paulsmith', email: 'paulsmith@email.com', id: 2) }
+  given(:user_two) do
+    create(:user, username: 'paulsmith', email: 'paulsmith@email.com', id: 2)
+  end
   given(:text)     { build :post }
   given(:message)  { build :comment }
 
@@ -21,7 +23,7 @@ feature 'Comments' do
 
   # As a User
   # So that I can rectify what I originally comment
-  # I want to delete my comment
+  # I want to delete my comments
   context 'deleting comments' do
     background do
       log_in_as user
@@ -38,10 +40,13 @@ feature 'Comments' do
       user_should_not_see_comment message
     end
 
+    # As a User
+    # So that I can protect comments from deleting by another user
+    # I want to delete comments that only belong to me
     scenario "can't delete a comment not belonging to them" do
       log_out
       log_in_as user
-      expect(page).to have_content "#{message.thoughts}"
+      expect(page).to have_content message.thoughts
       expect(page).to_not have_content 'Delete'
     end
 
@@ -50,7 +55,7 @@ feature 'Comments' do
       log_in_as user
       page.driver.submit :delete, "posts/4/comments/4", {}
       expect(page).to have_content "That comment doesn't belong to you!"
-      expect(page).to have_content "#{message.thoughts}"
+      expect(page).to have_content message.thoughts
     end
   end
 end

--- a/spec/features/comments/comments_feature_spec.rb
+++ b/spec/features/comments/comments_feature_spec.rb
@@ -6,16 +6,13 @@ feature 'Comments' do
   given(:text)     { build :post }
   given(:message)  { build :comment }
 
-  background do
-    log_in_as user
-    create_post_with text
-  end
-
   # As a User
   # So that I can let people know my thoughts
   # I want to leave a comment on picture
   context 'creating comments' do
     scenario 'can leave a comment on an existing post' do
+      log_in_as user
+      create_post_with text
       write_comment_with message
       user_should_see_username_of user
       user_should_see_comment message
@@ -27,16 +24,33 @@ feature 'Comments' do
   # I want to delete my comment
   context 'deleting comments' do
     background do
+      log_in_as user
+      create_post_with text
       log_out
       log_in_as user_two
+      write_comment_with message
     end
 
     scenario 'can delete a comment on an existing post' do
-      write_comment_with message
       user_should_see_comment message
       user_should_see_username_of user_two
       delete_comment
       user_should_not_see_comment message
+    end
+
+    scenario "can't delete a comment not belonging to them" do
+      log_out
+      log_in_as user
+      expect(page).to have_content "#{message.thoughts}"
+      expect(page).to_not have_content 'Delete'
+    end
+
+    scenario "can't delete a comment not belonging to them via urls" do
+      log_out
+      log_in_as user
+      page.driver.submit :delete, "posts/4/comments/4", {}
+      expect(page).to have_content "That comment doesn't belong to you!"
+      expect(page).to have_content "#{message.thoughts}"
     end
   end
 end

--- a/spec/features/posts/posts_feature_spec.rb
+++ b/spec/features/posts/posts_feature_spec.rb
@@ -63,8 +63,8 @@ feature 'Posts' do
     scenario 'can view an individual post' do
       create_post_with text
       visit root_path
-      find(:xpath, "//a[contains(@href,'posts/6')]").click
-      expect(page.current_path).to eq(post_path(6))
+      find(:xpath, "//a[contains(@href,'posts/8')]").click
+      expect(page.current_path).to eq(post_path(8))
     end
   end
 
@@ -90,19 +90,19 @@ feature 'Posts' do
 
     context "can't edit a post that doesn't belong to you" do
       scenario 'when visiting the show page' do
-        find(:xpath, "//a[contains(@href,'posts/11')]").click
+        find(:xpath, "//a[contains(@href,'posts/13')]").click
         expect(page).to_not have_content 'Edit Post'
       end
 
       scenario 'when the url path is directly visited' do
-        visit "/posts/11/edit"
+        visit "/posts/13/edit"
         expect(page.current_path).to eq root_path
         expect(page).to have_content "That post doesn't belong to you!"
       end
     end
 
     scenario "can't update a post without an attached image" do
-      find(:xpath, "//a[contains(@href,'posts/10')]").click
+      find(:xpath, "//a[contains(@href,'posts/12')]").click
       click_link 'Edit Post'
       attach_file('Image', 'spec/files/test.zip')
       click_button 'Update Post'

--- a/spec/features/posts/posts_feature_spec.rb
+++ b/spec/features/posts/posts_feature_spec.rb
@@ -118,7 +118,7 @@ feature 'Posts' do
       create_post_with text
       delete_post
       expect(page).not_to have_content "#{text.description}"
-      expect(page).to have_content 'Post deleted successfully'
+      expect(page).to have_content 'Post deleted successfully.'
     end
   end
 

--- a/spec/features/posts/posts_feature_spec.rb
+++ b/spec/features/posts/posts_feature_spec.rb
@@ -84,7 +84,7 @@ feature 'Posts' do
       other_text = build(:post, description: 'My edited post')
       edit_post_with other_text
       expect(current_path).to eq root_path
-      expect(page).to have_content "#{other_text.description}"
+      expect(page).to have_content other_text.description
       expect(page).to have_content 'Post updated successfully.'
     end
 
@@ -117,7 +117,7 @@ feature 'Posts' do
     scenario 'can remove a post' do
       create_post_with text
       delete_post
-      expect(page).not_to have_content "#{text.description}"
+      expect(page).not_to have_content text.description
       expect(page).to have_content 'Post deleted successfully.'
     end
   end

--- a/spec/features/posts/posts_feature_spec.rb
+++ b/spec/features/posts/posts_feature_spec.rb
@@ -63,8 +63,8 @@ feature 'Posts' do
     scenario 'can view an individual post' do
       create_post_with text
       visit root_path
-      find(:xpath, "//a[contains(@href,'posts/5')]").click
-      expect(page.current_path).to eq(post_path(5))
+      find(:xpath, "//a[contains(@href,'posts/6')]").click
+      expect(page.current_path).to eq(post_path(6))
     end
   end
 
@@ -90,19 +90,19 @@ feature 'Posts' do
 
     context "can't edit a post that doesn't belong to you" do
       scenario 'when visiting the show page' do
-        find(:xpath, "//a[contains(@href,'posts/10')]").click
+        find(:xpath, "//a[contains(@href,'posts/11')]").click
         expect(page).to_not have_content 'Edit Post'
       end
 
       scenario 'when the url path is directly visited' do
-        visit "/posts/10/edit"
+        visit "/posts/11/edit"
         expect(page.current_path).to eq root_path
         expect(page).to have_content "That post doesn't belong to you!"
       end
     end
 
     scenario "can't update a post without an attached image" do
-      find(:xpath, "//a[contains(@href,'posts/9')]").click
+      find(:xpath, "//a[contains(@href,'posts/10')]").click
       click_link 'Edit Post'
       attach_file('Image', 'spec/files/test.zip')
       click_button 'Update Post'
@@ -121,5 +121,4 @@ feature 'Posts' do
       expect(page).to have_content 'Post deleted successfully.'
     end
   end
-
 end

--- a/spec/features/users/new_user_registration_spec.rb
+++ b/spec/features/users/new_user_registration_spec.rb
@@ -25,6 +25,6 @@ feature 'User signs up' do
   scenario 'having a username with more than 16 characters' do
     user = build(:user, username: 'johndoeknucklesjames')
     sign_up_as user
-    expect(page).to have_content('maximum is 16 characters')
+    expect(page).to have_content 'maximum is 16 characters'
   end
 end

--- a/spec/helpers/comment_helper_spec.rb
+++ b/spec/helpers/comment_helper_spec.rb
@@ -11,4 +11,22 @@ module CommentHelpers
     visit root_path
     click_link 'Delete'
   end
+
+  def user_should_see_comment message
+    within '#comment' do
+      expect(page).to have_css '.comment-content', text: message.thoughts
+    end
+  end
+
+  def user_should_not_see_comment message
+    within '.comments' do
+      expect(page).not_to have_css '.comment-content', text: message.thoughts
+    end
+  end
+
+  def user_should_see_username_of user_two
+    within '#comment' do
+      expect(page).to have_css '.username', text: user_two.username
+    end
+  end
 end

--- a/spec/helpers/comment_helper_spec.rb
+++ b/spec/helpers/comment_helper_spec.rb
@@ -6,4 +6,9 @@ module CommentHelpers
     fill_in "comment[thoughts]", with: message.thoughts, match: :first
     click_button 'New comment', match: :first
   end
+
+  def delete_comment
+    visit root_path
+    click_link 'Delete'
+  end
 end

--- a/spec/helpers/post_helper_spec.rb
+++ b/spec/helpers/post_helper_spec.rb
@@ -11,7 +11,7 @@ module PostHelpers
 
   def edit_post_with text
     visit root_path
-    find(:xpath, "//a[contains(@href,'posts/7')]").click
+    find(:xpath, "//a[contains(@href,'posts/8')]").click
     click_link 'Edit Post'
     fill_in 'Description', with: text.description
     click_button 'Update Post'
@@ -19,7 +19,7 @@ module PostHelpers
 
   def delete_post
     visit root_path
-    find(:xpath, "//a[contains(@href,'posts/14')]").click
+    find(:xpath, "//a[contains(@href,'posts/15')]").click
     click_link 'Edit Post'
     click_link 'Delete Post'
   end

--- a/spec/helpers/post_helper_spec.rb
+++ b/spec/helpers/post_helper_spec.rb
@@ -11,7 +11,7 @@ module PostHelpers
 
   def edit_post_with text
     visit root_path
-    find(:xpath, "//a[contains(@href,'posts/8')]").click
+    find(:xpath, "//a[contains(@href,'posts/10')]").click
     click_link 'Edit Post'
     fill_in 'Description', with: text.description
     click_button 'Update Post'
@@ -19,7 +19,7 @@ module PostHelpers
 
   def delete_post
     visit root_path
-    find(:xpath, "//a[contains(@href,'posts/15')]").click
+    find(:xpath, "//a[contains(@href,'posts/17')]").click
     click_link 'Edit Post'
     click_link 'Delete Post'
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,7 +4,6 @@ Coveralls.wear!('rails')
 ENV['RAILS_ENV'] ||= 'test'
 require 'spec_helper'
 require File.expand_path('../../config/environment', __FILE__)
-
 require 'rspec/rails'
 require 'capybara/rails'
 
@@ -28,7 +27,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -7,7 +7,7 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
   end
 
-  config.before(:each, :js => true) do
+  config.before(:each, js: true) do
     DatabaseCleaner.strategy = :truncation
   end
 


### PR DESCRIPTION
Implement AJAX submission into the deletion of comments
```
As a User
So that I can rectify what I originally comment
I want to delete my comments
```
```
As a User
So that I can protect comments from deleting by another user
I want to delete comments that only belong to me
```
- Updated RuboCop config
- Added SCSS-lint and HAML-lint to Hound config
- Added link_to helper method within the comments that links to the DELETE request of the specific comment it’s referring to
- Added remote: true to the destroy form
- Added the responds_to method to the destroy action within the CommentsController
- Used the DOM manipulation with jQuery to delete the comments
- Added some extra security in the delete action and comment partial to ensure only the owner of a comment can delete it

