### PR TITLE
Add length limitations to description in a Post model

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,10 +1,12 @@
 class Post < ActiveRecord::Base
+  belongs_to :user
+  has_many :comments, dependent: :destroy
+
   validates :user_id, presence: true
   validates :image, presence: true
+  validates_length_of :description, in: 3..300
 
-  has_many :comments, dependent: :destroy
-  belongs_to :user
-  has_attached_file :image, :styles => { :medium => "600x" },
-                    :default_url => "missing.png"
-  validates_attachment_content_type :image, :content_type => /\Aimage\/.*\Z/
+  has_attached_file :image, styles: { medium: "600x" },
+                    default_url: "missing.png"
+  validates_attachment_content_type :image, content_type: %r{image/.*}
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,9 @@
 class User < ActiveRecord::Base
   validates :username, presence: true, length: { minimum: 3, maximum: 16 }
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+
   has_many :posts, dependent: :destroy
   has_many :comments, dependent: :destroy
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -7,7 +7,11 @@ describe Post do
   end
 
   context "validations" do
-    it { should validate_presence_of(:image) }
-    it { should validate_presence_of(:user_id) }
+    it { is_expected.to validate_presence_of(:image) }
+    it { is_expected.to validate_presence_of(:user_id) }
+    it do
+      is_expected.to validate_length_of(:description)
+        .is_at_least(3).is_at_most(300)
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,6 +7,6 @@ describe User do
   end
 
   context "validations" do
-    it { should validate_presence_of(:username) }
+    it { is_expected.to validate_presence_of(:username) }
   end
 end


### PR DESCRIPTION
Add a minimum and maximum length validation to the Posts model for the description column. It has minimum length 3 characters and maximum length 300 characters.