### PR TITLE
Add liking posts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'bootstrap-sass'
 gem 'simple_form'
 gem 'rails-timeago'
 gem 'puma'
+gem 'acts_as_votable'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    acts_as_votable (0.10.0)
     addressable (2.4.0)
     arel (6.0.3)
     autoprefixer-rails (6.3.6.1)
@@ -303,6 +304,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts_as_votable
   bootstrap-sass
   byebug
   capybara

--- a/README.md
+++ b/README.md
@@ -50,12 +50,24 @@ So that I can protect comments from deleting by another user
 I want to delete comments that only belong to me
 
 As a User
-So that I can register my appreciation of the picture
-I want to like other users' pictures
+So that I can add a 'Like' to the post
+I want to click a little heart icon under the image
 
 As a User
-So that I can't tally up the likes of a picture
-I want to like pictures once
+So that once I've liked a post
+I want to see my username added to the post's list of likers
+
+As a User
+So that I can revoke my decision
+I want to unlike a post by clicking the button again
+
+As a User
+So that once I've liked a post
+I want to see the heart icon turn solid upon clicking it
+
+As a User
+So that a post has more than or equal to 4 likes
+I want to see the number of likes
 ```
 
 ## Setup

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,19 +1,3 @@
-/*
- * This is a manifest file that'll be compiled into application.css, which will include all the files
- * listed below.
- *
- * Any CSS and SCSS file within this directory, lib/assets/stylesheets, vendor/assets/stylesheets,
- * or any plugin's vendor/assets/stylesheets directory can be referenced here using a relative path.
- *
- * You're free to add application-wide styles to this file and they'll appear at the bottom of the
- * compiled file so the styles you add here take precedence over styles defined in any styles
- * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
- * file per style scope.
- *
- *= require_tree .
- *= require_self
- */
-
 @import "bootstrap-sprockets";
 @import "bootstrap";
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,10 +13,12 @@
  *= require_tree .
  *= require_self
  */
+
 @import "bootstrap-sprockets";
 @import "bootstrap";
 
 @import "variables";
+@import "likes";
 
 body {
   background-color: $color-snow;
@@ -101,7 +103,6 @@ body {
   padding-bottom: 10px;
   padding-left: 24px;
   padding-right: 24px;
-  padding-top: 24px;
 
   .username,
   .comment-content {
@@ -114,7 +115,6 @@ body {
 
   .username {
     font-weight: 500;
-    margin-right: 0.3em;
     color: $color-bahamablue;
     font-size: 15px;
   }

--- a/app/assets/stylesheets/likes.scss
+++ b/app/assets/stylesheets/likes.scss
@@ -1,4 +1,11 @@
 .likes {
-  margin-top: 20px;
   margin-bottom: 7px;
+  margin-top: 20px;
+}
+
+.like,
+.like-button a:hover, a:focus {
+  color: $color-heart;
+  outline: none;
+  text-decoration: none;
 }

--- a/app/assets/stylesheets/likes.scss
+++ b/app/assets/stylesheets/likes.scss
@@ -1,0 +1,4 @@
+.likes {
+  margin-top: 20px;
+  margin-bottom: 7px;
+}

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -7,3 +7,4 @@ $color-steelgrey: #a5a7aa;
 $color-darkgrey: #4b4f54;
 $color-azure: #eeefef;
 $color-bahamablue: #125688;
+$color-heart: #ff0000;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_post, only: [:show, :edit, :update, :destroy, :like]
+  before_action :set_post, only: [:show, :edit, :update, :destroy, :like, :unlike]
   before_action :owned_post, only: [:edit, :update, :destroy]
 
   def index
@@ -50,6 +50,15 @@ class PostsController < ApplicationController
 
   def like
     if @post.liked_by current_user
+      respond_to do |format|
+        format.html { redirect_to :back }
+        format.js
+      end
+    end
+  end
+  
+  def unlike
+    if @post.unliked_by current_user
       respond_to do |format|
         format.html { redirect_to :back }
         format.js

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,6 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_post, only: [:show, :edit, :update, :destroy, :like]
   before_action :owned_post, only: [:edit, :update, :destroy]
 
   def index
@@ -22,15 +23,12 @@ class PostsController < ApplicationController
   end
 
   def show
-    @post = Post.find(params[:id])
   end
 
   def edit
-    @post = Post.find(params[:id])
   end
 
   def update
-    @post = Post.find(params[:id])
     if @post.update(post_params)
       flash[:success] = "Post updated successfully."
       redirect_to root_path
@@ -41,7 +39,6 @@ class PostsController < ApplicationController
   end
 
   def destroy
-    @post = Post.find(params[:id])
     if @post.destroy
       flash[:notice] = "Post deleted successfully."
       redirect_to root_path
@@ -52,7 +49,12 @@ class PostsController < ApplicationController
   end
 
   def like
-
+    if @post.liked_by current_user
+      respond_to do |format|
+        format.html { redirect_to :back }
+        format.js
+      end
+    end
   end
 
   private
@@ -69,4 +71,7 @@ class PostsController < ApplicationController
     end
   end
 
+  def set_post
+    @post = Post.find(params[:id])
+  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -51,6 +51,10 @@ class PostsController < ApplicationController
     end
   end
 
+  def like
+
+  end
+
   private
 
   def post_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
-  def alert_for flash_type
+  def alert_for(flash_type)
     {
       success: 'alert-success',
       error:   'alert-danger',

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -15,10 +15,10 @@ module PostsHelper
   def liked_post(post)
     if user_signed_in? && current_user.voted_for?(post)
       link_to '', unlike_post_path(post), remote: true, id: "like_#{post.id}",
-        class: 'glyphicon glyphicon-heart-empty'
+        class: 'like glyphicon glyphicon-heart'
     else
       link_to '', like_post_path(post), remote: true, id: "like_#{post.id}",
-        class: 'glyphicon glyphicon-heart-empty'
+        class: 'like glyphicon glyphicon-heart-empty'
     end
   end
 

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,6 +1,28 @@
 module PostsHelper
-  def likers_of(post)
+  def liked_post(post)
+    if user_signed_in? && current_user.voted_for?(post)
+      link_to '', unlike_post_path(post), remote: true, id: "like_#{post.id}",
+        class: 'like glyphicon glyphicon-heart'
+    else
+      link_to '', like_post_path(post), remote: true, id: "like_#{post.id}",
+        class: 'like glyphicon glyphicon-heart-empty'
+    end
+  end
+  
+  def display_likes(post)
     votes = post.votes_for.up.by_type(User)
+    return list_likers(votes) if votes.size < 4
+    count_likers(votes)
+  end
+
+  private
+
+  def like_plural(votes)
+    return ' like this' if votes.count > 1
+    ' likes this'
+  end
+  
+  def list_likers(votes)
     usernames = []
     unless votes.blank?
       votes.voters.each do |voter|
@@ -12,20 +34,8 @@ module PostsHelper
     end
   end
   
-  def liked_post(post)
-    if user_signed_in? && current_user.voted_for?(post)
-      link_to '', unlike_post_path(post), remote: true, id: "like_#{post.id}",
-        class: 'like glyphicon glyphicon-heart'
-    else
-      link_to '', like_post_path(post), remote: true, id: "like_#{post.id}",
-        class: 'like glyphicon glyphicon-heart-empty'
-    end
-  end
-
-  private
-
-  def like_plural(votes)
-    return ' like this' if votes.count > 1
-    ' likes this'
+  def count_likers(votes)
+    vote_count = votes.size
+    vote_count.to_s + ' likes'
   end
 end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -11,6 +11,16 @@ module PostsHelper
       usernames.to_sentence.html_safe + like_plural(votes)
     end
   end
+  
+  def liked_post(post)
+    if user_signed_in? && current_user.voted_for?(post)
+      link_to '', unlike_post_path(post), remote: true, id: "like_#{post.id}",
+        class: 'glyphicon glyphicon-heart-empty'
+    else
+      link_to '', like_post_path(post), remote: true, id: "like_#{post.id}",
+        class: 'glyphicon glyphicon-heart-empty'
+    end
+  end
 
   private
 

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,2 +1,21 @@
 module PostsHelper
+  def likers_of(post)
+    votes = post.votes_for.up.by_type(User)
+    usernames = []
+    unless votes.blank?
+      votes.voters.each do |voter|
+        usernames.push(link_to voter.username,
+                               'http://www.example.com',
+                               class: 'username')
+      end
+      usernames.to_sentence.html_safe + like_plural(votes)
+    end
+  end
+
+  private
+
+  def like_plural(votes)
+    return ' like this' if votes.count > 1
+    ' likes this'
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,6 @@
 class Post < ActiveRecord::Base
+  acts_as_votable
+
   belongs_to :user
   has_many :comments, dependent: :destroy
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ActiveRecord::Base
+  acts_as_voter
+  
   validates :username, presence: true, length: { minimum: 3, maximum: 16 }
 
   devise :database_authenticatable, :registerable,

--- a/app/views/posts/_likes.html.haml
+++ b/app/views/posts/_likes.html.haml
@@ -1,0 +1,2 @@
+.likes{ id: "likes_#{post.id}" }
+  = likers_of post

--- a/app/views/posts/_likes.html.haml
+++ b/app/views/posts/_likes.html.haml
@@ -1,2 +1,2 @@
 .likes{ id: "likes_#{post.id}" }
-  = likers_of post
+  = display_likes post

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -19,10 +19,7 @@
             = render post.comments, post: post
     .comment-like-form.row
       .col-sm-1
-        = link_to '', like_post_path(post.id),
-                      remote: true,
-                      id: "like_#{post.id}",
-                      class: 'glyphicon glyphicon-heart-empty'
+        = liked_post post
       .comment-form.col-sm-11
         = form_for([post, post.comments.build], remote: true) do |f|
           = f.text_field :thoughts, placeholder: 'Add a comment...',

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -8,6 +8,7 @@
     .image.center-block
       = link_to (image_tag post.image.url(:medium), class: 'img-responsive'), post_path(post)
     .post-bottom
+      = render 'posts/likes', post: post
       .description
         .description-content
           .username

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -18,7 +18,7 @@
           - if post.comments
             = render post.comments, post: post
     .comment-like-form.row
-      .col-sm-1
+      .col-sm-1.like-button
         = liked_post post
       .comment-form.col-sm-11
         = form_for([post, post.comments.build], remote: true) do |f|

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -17,7 +17,12 @@
           - if post.comments
             = render post.comments, post: post
     .comment-like-form.row
-      .comment-form.col-sm-11.col-sm-offset-1
+      .col-sm-1
+        = link_to '', like_post_path(post.id),
+                      remote: true,
+                      id: "like_#{post.id}",
+                      class: 'glyphicon glyphicon-heart-empty'
+      .comment-form.col-sm-11
         = form_for([post, post.comments.build], remote: true) do |f|
           = f.text_field :thoughts, placeholder: 'Add a comment...',
                                     class: "comment_content",

--- a/app/views/posts/like.js.erb
+++ b/app/views/posts/like.js.erb
@@ -1,0 +1,1 @@
+$("#likes_<%= @post.id %>").html("<%= j (render partial: 'posts/likes', locals: { post: @post} ) %>");

--- a/app/views/posts/like.js.erb
+++ b/app/views/posts/like.js.erb
@@ -1,2 +1,3 @@
 $("#likes_<%= @post.id %>").html("<%= j (render partial: 'posts/likes', locals: { post: @post} ) %>");
 $("#like_<%= @post.id %>").removeAttr('href').attr('href', '/posts/<%= @post.id %>/unlike');
+$("#like_<%= @post.id %>").removeClass('glyphicon-heart-empty').addClass('glyphicon-heart');

--- a/app/views/posts/unlike.js.erb
+++ b/app/views/posts/unlike.js.erb
@@ -1,2 +1,2 @@
 $("#likes_<%= @post.id %>").html("<%= j (render partial: 'posts/likes', locals: { post: @post} ) %>");
-$("#like_<%= @post.id %>").removeAttr('href').attr('href', '/posts/<%= @post.id %>/unlike');
+$("#like_<%= @post.id %>").removeAttr('href').attr('href', '/posts/<%= @post.id %>/like');

--- a/app/views/posts/unlike.js.erb
+++ b/app/views/posts/unlike.js.erb
@@ -1,2 +1,3 @@
 $("#likes_<%= @post.id %>").html("<%= j (render partial: 'posts/likes', locals: { post: @post} ) %>");
 $("#like_<%= @post.id %>").removeAttr('href').attr('href', '/posts/<%= @post.id %>/like');
+$("#like_<%= @post.id %>").removeClass('glyphicon-heart').addClass('glyphicon-heart-empty');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     resources :comments
     member do
       get 'like'
+      get 'unlike'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
 
   resources :posts do
     resources :comments
+    member do
+      get 'like'
+    end
   end
 end

--- a/db/migrate/20160726213308_acts_as_votable_migration.rb
+++ b/db/migrate/20160726213308_acts_as_votable_migration.rb
@@ -1,0 +1,27 @@
+class ActsAsVotableMigration < ActiveRecord::Migration
+  def self.up
+    create_table :votes do |t|
+
+      t.references :votable, :polymorphic => true
+      t.references :voter, :polymorphic => true
+
+      t.boolean :vote_flag
+      t.string :vote_scope
+      t.integer :vote_weight
+
+      t.timestamps
+    end
+
+    if ActiveRecord::VERSION::MAJOR < 4
+      add_index :votes, [:votable_id, :votable_type]
+      add_index :votes, [:voter_id, :voter_type]
+    end
+
+    add_index :votes, [:voter_id, :voter_type, :vote_scope]
+    add_index :votes, [:votable_id, :votable_type, :vote_scope]
+  end
+
+  def self.down
+    drop_table :votes
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160607224335) do
+ActiveRecord::Schema.define(version: 20160726213308) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,21 @@ ActiveRecord::Schema.define(version: 20160607224335) do
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
+
+  create_table "votes", force: :cascade do |t|
+    t.integer  "votable_id"
+    t.string   "votable_type"
+    t.integer  "voter_id"
+    t.string   "voter_type"
+    t.boolean  "vote_flag"
+    t.string   "vote_scope"
+    t.integer  "vote_weight"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "votes", ["votable_id", "votable_type", "vote_scope"], name: "index_votes_on_votable_id_and_votable_type_and_vote_scope", using: :btree
+  add_index "votes", ["voter_id", "voter_type", "vote_scope"], name: "index_votes_on_voter_id_and_voter_type_and_vote_scope", using: :btree
 
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"

--- a/spec/features/comments/comments_feature_spec.rb
+++ b/spec/features/comments/comments_feature_spec.rb
@@ -1,11 +1,10 @@
 require 'rails_helper'
 
 feature 'Comments' do
-  given(:user)      { create :user }
-  given(:user_2)    { create :user }
-  given(:text)      { create :post, user: user }
-  given(:message)   { build :comment, user: user, post: text }
-  given(:message_2) { build :comment, user: user_2, post: text }
+  given(:user)     { create :user }
+  given(:user_two) { create :user }
+  given!(:post)    { create :post, user: user }
+  given(:message)  { build :comment, user: user, post: post }
 
   # As a User
   # So that I can let people know my thoughts
@@ -17,8 +16,10 @@ feature 'Comments' do
 
     scenario 'can leave a comment on an existing post' do
       write_comment_with message
-      user_should_see_username_of user
-      user_should_see_comment message
+      within '#comment' do
+        expect(page).to have_css '.username', text: user.username
+        expect(page).to have_css '.comment-content', text: message.thoughts
+      end
     end
   end
 
@@ -26,34 +27,46 @@ feature 'Comments' do
   # So that I can rectify what I originally comment
   # I want to delete my comments
   context 'deleting comments' do
+    given!(:message_two) { create :comment, user: user_two, post: post }
+
     background do
-      log_in_as user_2
-      write_comment_with message_2
+      log_in_as user_two
     end
 
     scenario 'can delete a comment on an existing post' do
-      user_should_see_comment message_2
-      user_should_see_username_of user_2
+      within '#comment' do
+        expect(page).to have_css '.username', text: user_two.username
+        expect(page).to have_css '.comment-content', text: message_two.thoughts
+      end
       delete_comment
-      user_should_not_see_comment message_2
+      within '.comments' do
+        expect(page).not_to have_css '.comment-content', text: message_two.thoughts
+      end
     end
 
     # As a User
     # So that I can protect comments from deleting by another user
     # I want to delete comments that only belong to me
-    scenario "can't delete a comment not belonging to them" do
-      log_out
-      log_in_as user
-      user_should_see_comment message_2
-      user_should_not_see_link 'Delete'
-    end
+    context "can't delete a comment not belonging to them" do
+      background do
+        log_out
+        log_in_as user
+      end
 
-    scenario "can't delete a comment not belonging to them via urls" do
-      log_out
-      log_in_as user
-      page.driver.submit :delete, "posts/4/comments/4", {}
-      user_should_see_alert "That comment doesn't belong to you!"
-      user_should_see_comment message_2
+      scenario 'via the user interface' do
+        within '#comment' do
+          expect(page).to have_css '.comment-content', text: message_two.thoughts
+          expect(page).not_to have_css '.delete-comment', text: 'Delete'
+        end
+      end
+
+      scenario 'via the URLs' do
+        page.driver.submit :delete, "posts/#{post.id}/comments/#{message_two.id}", {}
+        expect(page).to have_content "That comment doesn't belong to you!"
+        within '#comment' do
+          expect(page).to have_css '.comment-content', text: message_two.thoughts
+        end
+      end
     end
   end
 end

--- a/spec/features/likes/likes_feature_spec.rb
+++ b/spec/features/likes/likes_feature_spec.rb
@@ -36,4 +36,14 @@ feature 'Liking posts' do
     click_link "like_#{post.id}"
     expect(find('.likes')).to_not have_content user.username
   end
+  
+  # As a User
+  # So that once I've liked a post
+  # I want to see the heart icon turn solid upon clicking it
+  scenario 'can see the heart turn solid red upon liking' do
+    visit root_path
+    expect(page).to have_css('a.glyphicon-heart-empty')
+    click_link "like_#{post.id}"
+    expect(page).to have_css('a.glyphicon-heart')
+  end
 end

--- a/spec/features/likes/likes_feature_spec.rb
+++ b/spec/features/likes/likes_feature_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+feature 'Liking posts' do
+  given(:user) { create :user }
+  given!(:post) { create :post, user: user }
+
+  background do
+    log_in_as user
+  end
+
+  scenario 'can like a post' do
+    visit root_path
+    expect(page).to have_css 'a.glyphicon-heart-empty'
+  end
+end

--- a/spec/features/likes/likes_feature_spec.rb
+++ b/spec/features/likes/likes_feature_spec.rb
@@ -9,7 +9,7 @@ feature 'Liking posts' do
   end
 
   # As a User
-  # So that I can add a ‘Like’ to the post
+  # So that I can add a 'Like' to the post
   # I want to click a little heart icon under the image
   scenario "can add 'Like' to the post" do
     visit root_path
@@ -17,12 +17,23 @@ feature 'Liking posts' do
   end
 
   # As a User
-  # So that once I’ve liked a post
-  # I want to see my username added to the post’s list of likers
+  # So that once I've liked a post
+  # I want to see my username added to the post's list of likers
   scenario "can see username added to the post's list of likers" do
     visit root_path
     expect(find('.likes')).to_not have_content user.username
     click_link "like_#{post.id}"
     expect(find('.likes')).to have_content user.username
+  end
+  
+  # As a User
+  # So that I can revoke my decision
+  # I want to unlike a post by clicking the button again
+  scenario 'can unlike a post' do
+    visit root_path
+    click_link "like_#{post.id}"
+    expect(find('.likes')).to have_content user.username
+    click_link "like_#{post.id}"
+    expect(find('.likes')).to_not have_content user.username
   end
 end

--- a/spec/features/likes/likes_feature_spec.rb
+++ b/spec/features/likes/likes_feature_spec.rb
@@ -46,4 +46,19 @@ feature 'Liking posts' do
     click_link "like_#{post.id}"
     expect(page).to have_css('a.glyphicon-heart')
   end
+  
+  # As a User
+  # So that a post has more than or equal to 4 likes
+  # I want to see the number of likes
+  context 'when a post has more than or equal to 4 likes' do
+    scenario 'can see the number of likes' do
+      created_users = create_list(:user, 4)
+      created_users.each do |user|
+        log_out
+        log_in_as user
+        click_link "like_#{post.id}"
+      end  
+      expect(find('.likes')).to have_content '4 likes'
+    end
+  end
 end

--- a/spec/features/likes/likes_feature_spec.rb
+++ b/spec/features/likes/likes_feature_spec.rb
@@ -1,15 +1,28 @@
 require 'rails_helper'
 
 feature 'Liking posts' do
-  given(:user) { create :user }
+  given(:user)  { create :user }
   given!(:post) { create :post, user: user }
 
   background do
     log_in_as user
   end
 
-  scenario 'can like a post' do
+  # As a User
+  # So that I can add a ‘Like’ to the post
+  # I want to click a little heart icon under the image
+  scenario "can add 'Like' to the post" do
     visit root_path
     expect(page).to have_css 'a.glyphicon-heart-empty'
+  end
+
+  # As a User
+  # So that once I’ve liked a post
+  # I want to see my username added to the post’s list of likers
+  scenario "can see username added to the post's list of likers" do
+    visit root_path
+    expect(find('.likes')).to_not have_content user.username
+    click_link "like_#{post.id}"
+    expect(find('.likes')).to have_content user.username
   end
 end

--- a/spec/helpers/comment_helper_spec.rb
+++ b/spec/helpers/comment_helper_spec.rb
@@ -11,32 +11,4 @@ module CommentHelpers
     visit root_path
     click_link 'Delete'
   end
-
-  def user_should_see_comment message
-    within '#comment' do
-      expect(page).to have_css '.comment-content', text: message.thoughts
-    end
-  end
-
-  def user_should_not_see_comment message
-    within '.comments' do
-      expect(page).not_to have_css '.comment-content', text: message.thoughts
-    end
-  end
-
-  def user_should_see_username_of user
-    within '#comment' do
-      expect(page).to have_css '.username', text: user.username
-    end
-  end
-
-  def user_should_not_see_link message
-    within '#comment' do
-      expect(page).not_to have_css '.delete-comment', text: message
-    end
-  end
-
-  def user_should_see_alert message
-    expect(page).to have_css '.alert', text: message
-  end
 end

--- a/spec/helpers/post_helper_spec.rb
+++ b/spec/helpers/post_helper_spec.rb
@@ -11,7 +11,7 @@ module PostHelpers
 
   def edit_post_with text
     visit root_path
-    find(:xpath, "//a[contains(@href,'posts/1')]").click
+    find(:xpath, "//a[contains(@href,'posts/#{post.id}')]", match: :first).click
     click_link 'Edit Post'
     fill_in 'Description', with: text.description
     click_button 'Update Post'
@@ -19,7 +19,7 @@ module PostHelpers
 
   def delete_post
     visit root_path
-    find(:xpath, "//a[contains(@href,'posts/5')]").click
+    find(:xpath, "//a[contains(@href,'posts/#{post.id}')]", match: :first).click
     click_link 'Edit Post'
     click_link 'Delete Post'
   end


### PR DESCRIPTION
Implement instantly adding likes to posts using AJAX
```
As a User
So that I can add a 'Like' to the post
I want to click a little heart icon under the image

As a User
So that once I've liked a post
I want to see my username added to the post's list of likers

As a User
So that I can revoke my decision
I want to unlike a post by clicking the button again

As a User
So that once I've liked a post
I want to see the heart icon turn solid upon clicking it

As a User
So that a post has more than or equal to 4 likers
I want to see the number of likers
```
- Added `like` and `inlike` actions within the `PostsController`
- Added a Like to the post upon clicking the heart icon
- Added username to the post’s list of likers using AJAX
- Added unlike a post by clicking the button again
- Added changing the heart icon solid red upon liking
- Added displaying Likes in two ways: if a post has less than or equal to 4 likes, we'll list their names and if it has any more, we’ll display the number of likes
- Refactored `posts_feature_spec` and `comments_feature_spec`