### PR TITLE
Add paginating notifications

### DIFF
--- a/app/assets/javascripts/notifications.js
+++ b/app/assets/javascripts/notifications.js
@@ -1,0 +1,5 @@
+$(document).ready(function() {
+  if ($('.all-notifications').length == 0) {
+    $('.paginator-link').remove();
+  }
+});

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -6,13 +6,44 @@
   }
 }
 
-.notification-index-list {
-  list-style: none;
-  margin-top: 20px;
+.dropdown-menu {
+  margin: 0;
+  padding: 0;
+  width: 300px;
+}
 
-  li {
-    background-color: $color-white;
-    margin-top: 10px;
-    padding: 15px;
-  }
+.dropdown-menu-head {
+  padding: 8px;
+}
+
+.dropdown-menu-bottom {
+  border-top: 1px solid $color-lightgrey;
+  padding: 8px;
+}
+
+.notifications {
+  margin: 0 auto;
+  margin-bottom: 40px;
+  margin-top: 20px;
+  width: 550px;
+}
+
+.notification-head {
+  background-color: $color-white;
+  color: $color-black;
+  font-size: 16px;
+  padding: 15px;
+  text-align: center;
+}
+
+.notification {
+  background-color: $color-white;
+  border-top: 1px solid $color-lightgrey;
+  padding: 15px;
+}
+
+.paginator-link {
+  background-color: $color-white;
+  border-top: 1px solid $color-lightgrey;
+  padding: 15px;
 }

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,6 +1,8 @@
 class NotificationsController < ApplicationController
   def index
-    @notifications = current_user.notifications.order(created_at: :desc)
+    @notifications = current_user.notifications
+                                 .order(created_at: :desc)
+                                 .page(params[:page])
   end
 
   def link_through

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,4 +1,6 @@
 class Notification < ActiveRecord::Base
+  paginates_per 20
+
   belongs_to :user
   belongs_to :notified_by, class_name: 'User'
   belongs_to :post

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,8 @@
 class Post < ActiveRecord::Base
   acts_as_votable
 
+  paginates_per 12
+
   belongs_to :user
   has_many :comments, dependent: :destroy
   has_many :notifications, dependent: :destroy

--- a/app/views/notifications/_notification.html.haml
+++ b/app/views/notifications/_notification.html.haml
@@ -1,4 +1,4 @@
-%li.notification
+.notification
   = link_to link_through_path(notification) do
     = t('notifications.dropdown-menu.item',
         username: notification.notified_by.username,

--- a/app/views/notifications/_notification_dropdown.html.haml
+++ b/app/views/notifications/_notification_dropdown.html.haml
@@ -7,10 +7,8 @@
     = current_user.notifications.where(read: false).count
     %span.glyphicon.glyphicon-flag
   %ul.dropdown-menu{ 'aria-labelledby': 'dropdownMenu1' }
-    %li.text-center
+    %li.dropdown-menu-head.text-center
       = t('notifications.dropdown-menu.header')
-    %li.divider{ role: 'separator' }
     = render current_user.notifications.where(read: false).order(created_at: :desc).last(5)
-    %li.divider{ role: 'separator' }
-    %li.text-center
+    %li.dropdown-menu-bottom.text-center
       = link_to t('notifications.dropdown-menu.link'), notifications_path

--- a/app/views/notifications/_notifications.html.haml
+++ b/app/views/notifications/_notifications.html.haml
@@ -1,0 +1,2 @@
+- @notifications.each do |notification|
+  = render 'notification', notification: notification

--- a/app/views/notifications/index.html.haml
+++ b/app/views/notifications/index.html.haml
@@ -4,4 +4,7 @@
       %ul.notification-index-list
         %li.text-center
           = t('notifications.index.header')
-        = render @notifications
+        - if @notifications.any?
+          = render @notifications
+        - else
+          = t('notifications.index.empty')

--- a/app/views/notifications/index.html.haml
+++ b/app/views/notifications/index.html.haml
@@ -1,10 +1,12 @@
-.container
-  .row
-    .col-md-6.col-md-offset-3
-      %ul.notification-index-list
-        %li.text-center
-          = t('notifications.index.header')
-        - if @notifications.any?
-          = render @notifications
-        - else
-          = t('notifications.index.empty')
+.notifications
+  .notification-head
+    = t('notifications.index.header')
+  - if @notifications.any?
+    = render 'notifications'
+  - else
+    = t('notifications.index.empty')
+  .paginator-link.text-center
+    = link_to_next_page @notifications, t('paginator.link',
+                                        items: 'notifications'),
+                                        remote: true,
+                                        class: 'all-notifications'

--- a/app/views/notifications/index.js.erb
+++ b/app/views/notifications/index.js.erb
@@ -1,0 +1,3 @@
+$('.notifications').append('<%=j render 'notifications' %>');
+$('.paginator-link').html('<%=j link_to_next_page(@notifications, 'All notifications', remote: true, class: 'all-notifications') %>');
+if (!$('.all-notifications').length) { $('.paginator-link').remove(); }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,7 @@ en:
 
   paginator:
     button: "Load more"
+    link: "All %{items}"
 
   comments:
     add: "Add a comment..."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,3 +76,4 @@ en:
       link: "See All"
     index:
       header: "Notifications"
+      empty: "There are no notifications"

--- a/spec/features/notifications/paginating_notifications_spec.rb
+++ b/spec/features/notifications/paginating_notifications_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+# As a User
+# So that I can see only 20 notifications at a time in the index view
+# I want to paginate notifications
+feature 'Paginating notifications' do
+  given(:user)  { create :user }
+  given!(:post) { create :post }
+  given!(:notified_by_user) { create :user }
+
+  scenario 'with less than one page of posts', js: true do
+    create_list(:notification,
+                10,
+                post: post,
+                user: user,
+                notified_by: notified_by_user)
+
+    log_in_as user
+
+    visit notifications_path
+
+    expect(page).to have_displayed_notifications(10)
+    expect(page).to_not have_paginator_link
+  end
+
+  scenario 'viewing the first page of notifications' do
+    create_list(:notification,
+                24,
+                post: post,
+                user: user,
+                notified_by: notified_by_user)
+
+    log_in_as user
+
+    visit notifications_path
+
+    expect(page).to have_displayed_notifications(20)
+  end
+
+  scenario 'paginating through the notifications' do
+    create_list(:notification,
+                24,
+                post: post,
+                user: user,
+                notified_by: notified_by_user)
+
+    log_in_as user
+
+    visit notifications_path
+
+    click_link t('paginator.link', items: 'notifications')
+
+    expect(page).to have_displayed_notifications(4)
+  end
+end
+

--- a/spec/features/notifications/viewing_notifications_spec.rb
+++ b/spec/features/notifications/viewing_notifications_spec.rb
@@ -6,74 +6,88 @@ feature 'Viewing notifications' do
   given(:notified_by_user) { create :user }
 
   background do
-    create_list(:notification,
-                10,
-                post: post,
-                user: user,
-                notified_by: notified_by_user)
-
     log_in_as user
   end
 
-  # As a User
-  # So that I can find out when someone comments on my post
-  # I want to display the notification count on navbar
-  scenario 'can see the number of notifications on navbar' do
-    expect(page).to have_icon_flag
-    expect(page).to have_notification_count '10'
+  context 'no notifications have been added' do
+    scenario 'displays a message that there are no notifications' do
+      visit notifications_path
+
+      expect(page).to have_content t('notifications.index.empty')
+    end
   end
 
-  # As a User
-  # So that I can see only unread notifications in the navbar
-  # I want to mark visited notifications as read
-  scenario 'can see only unread notifications in the navbar' do
-    6.times do
-      click_link t('notifications.dropdown-menu.item',
-                   username: notified_by_user.username,
-                   notice_type: 'comment'),
-                   match: :first
+  context 'when notifications have been added' do
+    background do
+      create_list(:notification,
+                  10,
+                  post: post,
+                  user: user,
+                  notified_by: notified_by_user)
+
+      visit notifications_path
     end
 
-    expect(page).to have_current_path post_path(post)
-    expect(page).to have_notification_count '4'
-  end
-
-  # As a User
-  # So that I can see the limited amount of notifications in the navbar
-  # I want to show only the last 5 unread notifications
-  scenario 'can see only the last 5 unread notifications in the navbar' do
-    expect(page).to have_unread_notifications(5)
-  end
-
-  # As a User
-  # So that I can see all notifications in the index view
-  # I want to navigate to the notification index page via the top dropdown menu
-  scenario 'can see all notifications in the index view' do
-    click_link t('notifications.dropdown-menu.link')
-
-    expect(page).to have_current_path notifications_path
-    expect(page).to have_displayed_notifications(10)
-  end
-
-  # As a User
-  # So that I can better appreciate the context of a notification
-  # I want to see how long ago notification was created
-  scenario 'can see a notification with a created date', js: true do
-    different_times = [12.minutes.ago, 4.hours.ago, 5.years.ago]
-    different_times.each do |time|
-      create(:notification,
-             user: user,
-             post: post,
-             notified_by: notified_by_user,
-             created_at: time)
+    # As a User
+    # So that I can find out when someone comments on my post
+    # I want to display the notification count on navbar
+    scenario 'can see the number of notifications on navbar' do
+      expect(page).to have_icon_flag
+      expect(page).to have_notification_count '10'
     end
 
-    visit notifications_path
+    # As a User
+    # So that I can see only unread notifications in the navbar
+    # I want to mark visited notifications as read
+    scenario 'can see only unread notifications in the navbar' do
+      6.times do
+        click_link t('notifications.dropdown-menu.item',
+                     username: notified_by_user.username,
+                     notice_type: 'comment'),
+                     match: :first
+      end
 
-    travel_to Time.zone.now do
-      expect(page).to have_content '12 minutes ago'
-      expect(page).to have_content 'about 4 hours ago'
-      expect(page).to have_content '5 years ago'
+      expect(page).to have_current_path post_path(post)
+      expect(page).to have_notification_count '4'
+    end
+
+    # As a User
+    # So that I can see the limited amount of notifications in the navbar
+    # I want to show only the last 5 unread notifications
+    scenario 'can see only the last 5 unread notifications in the navbar' do
+      expect(page).to have_unread_notifications(5)
+    end
+
+    # As a User
+    # So that I can see all notifications in the index view
+    # I want to navigate to the notification index page via the top dropdown menu
+    scenario 'can see all notifications in the index view' do
+      click_link t('notifications.dropdown-menu.link')
+
+      expect(page).to have_current_path notifications_path
+      expect(page).to have_displayed_notifications(10)
+    end
+
+    # As a User
+    # So that I can better appreciate the context of a notification
+    # I want to see how long ago notification was created
+    scenario 'can see a notification with a created date', js: true do
+      different_times = [12.minutes.ago, 4.hours.ago, 5.years.ago]
+      different_times.each do |time|
+        create(:notification,
+               user: user,
+               post: post,
+               notified_by: notified_by_user,
+               created_at: time)
+      end
+
+      visit notifications_path
+
+      travel_to Time.zone.now do
+        expect(page).to have_content '12 minutes ago'
+        expect(page).to have_content 'about 4 hours ago'
+        expect(page).to have_content '5 years ago'
+      end
     end
   end
 end

--- a/spec/support/features/notifications_helper.rb
+++ b/spec/support/features/notifications_helper.rb
@@ -12,6 +12,10 @@ module NotificationsHelpers
   end
 
   def have_displayed_notifications(count)
-    have_css('.notification-index-list .notification', count: count)
+    have_css('.notifications .notification', count: count)
+  end
+
+  def have_paginator_link
+    have_css('.paginator-link')
   end
 end


### PR DESCRIPTION
```
As a User
So that I can see only 20 notifications at a time in the index view
I want to paginate notifications
```
This PR introduces the `Kaminari` gem to handle pagination.

If there are less than 20 notifications on the notification index page then the 'All notifications' link is not shown.