### PR TITLE
Redirect to registration page if not logged in

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,5 +13,6 @@ module Pixagram
     # -- all .rb files in that directory are automatically loaded.
     config.assets.enabled = true
     config.assets.paths << Rails.root.join('/app/assets/fonts')
+    config.autoload_paths << Rails.root.join('lib')
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -259,4 +259,8 @@ Devise.setup do |config|
   # When using OmniAuth, Devise cannot automatically set OmniAuth path,
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
+
+  config.warden do |manager|
+    manager.failure_app = CustomFailure
+  end
 end

--- a/lib/custom_failure.rb
+++ b/lib/custom_failure.rb
@@ -1,0 +1,13 @@
+class CustomFailure < Devise::FailureApp
+  def redirect_url
+    new_user_registration_url
+  end
+
+  def respond
+    if http_auth?
+      http_auth
+    else
+      redirect
+    end
+  end
+end

--- a/spec/features/users/user_logs_in_spec.rb
+++ b/spec/features/users/user_logs_in_spec.rb
@@ -2,35 +2,35 @@ require 'rails_helper'
 
 # As a User
 # So that I can post pictures on Pixagram as me
-# I want to log in and out of my account
-feature 'User logs in and out' do
-  context 'user not logged in and on the homepage' do
-    scenario "should see 'Sign up' link" do
+# I want to be able to log in
+feature 'User logs in' do
+  context 'User is not signed up' do
+    scenario 'navigates to the homepage' do
       visit root_path
 
-      expect(page).to have_link t('application.header.signup'),
-                                href: new_user_registration_path
+      expect(page).to have_current_path new_user_registration_path
     end
 
-    scenario "should not see a 'Log out' link" do
+    scenario "can't see a 'Log out' link" do
       visit root_path
 
       expect(page).not_to have_link t('application.header.logout'),
                                     href: destroy_user_session_path
     end
 
-    scenario 'cannot create a new post without logging in' do
+    scenario "can't create a new post without logging in" do
       visit new_post_path
 
-      expect(page).to have_content t('devise.failure.unauthenticated')
+      expect(page).to have_current_path new_user_registration_path
     end
   end
 
-  context 'user logged in on the homepage' do
-    given(:user) { create :user }
-    background { log_in_as user }
+  context 'User is logged in successfully' do
+    scenario "can't see 'Log in' and 'Sign up' links" do
+      user = create :user
 
-    scenario "should not see 'Log in' and 'Sign up' links" do
+      log_in_as user
+
       expect(current_path).to eq root_path
       expect(page).to have_content t('devise.sessions.signed_in')
       expect(page).not_to have_link t('application.header.login'),
@@ -39,16 +39,14 @@ feature 'User logs in and out' do
                                     href: new_user_registration_path
     end
 
-    scenario "should see a 'Log out' link" do
+    scenario "can see a 'Log out' link" do
+      user = create :user
+
+      log_in_as user
+
       expect(current_path).to eq root_path
       expect(page).to have_link t('application.header.logout'),
                                 href: destroy_user_session_path
-    end
-
-    scenario 'can log out once logged in' do
-      log_out
-
-      expect(page).to have_content t('devise.failure.unauthenticated')
     end
   end
 end

--- a/spec/features/users/user_logs_out_spec.rb
+++ b/spec/features/users/user_logs_out_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# As a logged-in User
+# So that no one else can use my account
+# I want to log out
+feature 'User logs out' do
+  scenario 'to end his session on the website' do
+    user = create :user
+
+    log_in_as user
+    log_out
+
+    expect(page).to have_current_path new_user_registration_path
+  end
+end

--- a/spec/features/users/visitor_creates_account_spec.rb
+++ b/spec/features/users/visitor_creates_account_spec.rb
@@ -1,40 +1,40 @@
 require 'rails_helper'
 
-# As a User
+# As a Visitor
 # So that I can post pictures on Pixagram as me
 # I want to register for my account
-feature 'User signs up' do
+feature 'Visitor creates an account' do
   scenario 'with valid credentials' do
-    user = build :user
+    visitor = build :user
 
-    sign_up_as user
+    sign_up_as visitor
 
     expect(page).to have_content t('devise.registrations.signed_up')
   end
 
   scenario 'without a username' do
-    user = build(:user, username: nil)
+    visitor = build(:user, username: nil)
 
-    sign_up_as user
+    sign_up_as visitor
 
     expect(page).to have_content t('errors.messages.blank')
   end
 
   context 'having a username with' do
     scenario 'less than 3 characters' do
-      user = build(:user, username: 'w')
+      visitor = build(:user, username: 'w')
 
-      sign_up_as user
+      sign_up_as visitor
 
       expect(page).to have_content t('errors.messages.too_short.other', count: 3)
     end
-  end
 
-  scenario 'having a username with more than 12 characters' do
-    user = build(:user, username: 'johndoeknucklesjames')
+    scenario 'more than 12 characters' do
+      visitor = build(:user, username: 'johndoeknucklesjames')
 
-    sign_up_as user
+      sign_up_as visitor
 
-    expect(page).to have_content t('errors.messages.too_long.other', count: 12)
+      expect(page).to have_content t('errors.messages.too_long.other', count: 12)
+    end
   end
 end

--- a/spec/support/features/authorization_helper.rb
+++ b/spec/support/features/authorization_helper.rb
@@ -1,7 +1,6 @@
 module AuthHelpers
   def sign_up_as(user)
     visit root_path
-    click_link t('application.header.signup')
     fill_in t('registration.email'), with: user.email
     fill_in t('registration.username'), with: user.username
     fill_in t('registration.password'), with: user.password, match: :first


### PR DESCRIPTION
This PR adds a `CustomFailure` app inherited from Devise `FailureApp` using the specific redirect url. And thus, non-authenticated users will be redirected to the registration page.